### PR TITLE
reorganize build provenance attestation

### DIFF
--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -1,0 +1,51 @@
+name: Sign Artifact
+
+on:
+  workflow_call:
+    inputs:
+    
+      subject-path:
+        required: false
+        type: string
+
+      push-to-registry:
+        required: false
+        type: boolean
+
+      show-summary:
+        required: false
+        type: boolean
+
+jobs:
+  sign-artifact:
+    name: Sign Artifact
+
+    outputs:
+      attestation-url: ${{ steps.attest.outputs.attestation-url }}
+      attestation-id: ${{ steps.attest.outputs.attestation-id }}
+      bundle-path: ${{ steps.attest.outputs.bundle-path }}
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    steps:
+    # Download the artifacts uploaded by the build job
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: build-artifacts
+        path: release
+
+    - name: Attest Build Provenance
+      id: attest
+      uses: actions/attest-build-provenance@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        subject-path: ${{ inputs.subject-path }}
+        push-to-registry: ${{ inputs.push-to-registry }}
+        show-summary: ${{ inputs.show-summary }}

--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -21,9 +21,9 @@ jobs:
     name: Sign Artifact
 
     outputs:
-      attestation-url: ${{ steps.attest.outputs.attestation-url }}
-      attestation-id: ${{ steps.attest.outputs.attestation-id }}
-      bundle-path: ${{ steps.attest.outputs.bundle-path }}
+      attestation-url: ${{ steps.collect.outputs.attestation-url }}
+      attestation-id: ${{ steps.collect.outputs.attestation-id }}
+      bundle-path: ${{ steps.collect.outputs.bundle-path }}
 
     runs-on: ubuntu-latest
 
@@ -49,3 +49,10 @@ jobs:
         subject-path: ${{ inputs.subject-path }}
         push-to-registry: ${{ inputs.push-to-registry }}
         show-summary: ${{ inputs.show-summary }}
+
+    - name: Set outputs
+      id: collect
+      run: |
+        echo "attestation-url=${{ steps.attest.outputs.attestation-url }}" >> $GITHUB_OUTPUT
+        echo "attestation-id=${{ steps.attest.outputs.attestation-id }}" >> $GITHUB_OUTPUT
+        echo "bundle-path=${{ steps.attest.outputs.bundle-path }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -7,6 +7,7 @@ on:
       subject-path:
         required: false
         type: string
+        default: 'release'
 
       push-to-registry:
         required: false
@@ -15,10 +16,19 @@ on:
       show-summary:
         required: false
         type: boolean
+    outputs:
+      attestation-url:
+        value: ${{ jobs.sign-artifact.outputs.attestation-url }}
+
+      attestation-id:
+        value: ${{ jobs.sign-artifact.outputs.attestation-id }}
+
+      bundle-path:
+        value: ${{ jobs.sign-artifact.outputs.bundle-path }}
 
 jobs:
   sign-artifact:
-    name: Sign Artifact
+    name: Sign Artifacts
 
     outputs:
       attestation-url: ${{ steps.collect.outputs.attestation-url }}
@@ -38,7 +48,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: build-artifacts
-        path: release
+        path: ${{ inputs.subject-path }}
 
     - name: Attest Build Provenance
       id: attest
@@ -46,7 +56,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        subject-path: ${{ inputs.subject-path }}
+        subject-path: ${{ inputs.subject-path }}/*
         push-to-registry: ${{ inputs.push-to-registry }}
         show-summary: ${{ inputs.show-summary }}
 

--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -113,10 +113,10 @@ jobs:
       id-token: write
       contents: read
     if: needs.draft_release.outputs.clean_semver == 'true'
-    uses: eliheady/wtutf/.github/workflows/attest.yml@3550b0891a0a53bd2415c585357b3226009dc6d1
+    uses: eliheady/wtutf/.github/workflows/attest.yml@7e50f5f9eae87d67038d21816f915f26bebe3d65
     secrets: inherit
     with:
-        subject-path: 'release/*'
+      subject-path: 'release/*'
 
   notes:
     runs-on: ubuntu-latest
@@ -151,7 +151,7 @@ jobs:
     - name: Attestation Notes
       if: needs.draft_release.outputs.clean_semver == 'true'
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         RELEASE_TAG: ${{ needs.draft_release.outputs.release-tag }}
         RELEASE_ID: ${{ needs.draft_release.outputs.release-id }}
         ATTESTATION_URL: ${{ needs.attest.outputs.attestation-url }}

--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -159,7 +159,7 @@ jobs:
         tmpfile=$(mktemp)
         RELEASE_NOTES_FILE=$tmpfile-notes.md
         echo $RELEASE_NOTES_FILE
-        gh release view $RELEASE_TAG --json body | jq -r '.body' > $RELEASE_NOTES_FILE
+        gh release view $RELEASE_TAG --json body -R ${{ github.repository }} | jq -r '.body' > $RELEASE_NOTES_FILE
         cat >> $RELEASE_NOTES_FILE <<EOF
         ## Verify Release Artifacts
 
@@ -172,6 +172,7 @@ jobs:
         gh attestation verify checksums.txt -R ${{ github.repository }} -t $RELEASE_TAG
         \`\`\`
         EOF
+        # "gh release edit" can sometimes create new releases, which is not what we want here.
         #gh release edit ${RELEASE_TAG} --notes-file $RELEASE_NOTES_FILE
         gh api --method PATCH \
           -H "Accept: application/vnd.github.v3+json" \

--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -122,21 +122,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [draft_release, attest]
     name: Add Release Notes
-    outputs:
-      image-digest: ${{ steps.metadata.outputs.image-digest }}
-      image-name: ${{ steps.metadata.outputs.image-name }}
-      release-id: ${{ steps.metadata.outputs.release-id }}
 
     steps:
-    - name: Collect Metadata
-      id: metadata
-      env:
-        ARTIFACTS: ${{ needs.draft_release.outputs.artifacts }}
-        METADATA:  ${{ needs.draft_release.outputs.metadata }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Debug Attest Outputs
       run: |
-        echo "artifacts=$(echo "$ARTIFACTS" )" >> "$GITHUB_OUTPUT"
-        echo "metadata=$(echo "$METADATA" )" >> "$GITHUB_OUTPUT"
+        echo "Attest outputs: ${{ toJson(needs.attest.outputs) }}"
 
     #- name: Generate container attestation
     #  uses: actions/attest-build-provenance@v2

--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -18,14 +18,12 @@ jobs:
 
     outputs:
 
-      artifacts: ${{ steps.metadata.outputs.artifacts }}
-      attestation-url: ${{ steps.attest.outputs.attestation-url }}
-      image-digest: ${{ steps.metadata.outputs.image-digest }}
-      image-name: ${{ steps.metadata.outputs.image-name }}
-      metadata: ${{ steps.metadata.outputs.metadata }}
-      release-id: ${{ steps.metadata.outputs.release-id }}
-      release-tag: ${{ steps.metadata.outputs.release-tag }}
-
+      artifacts: ${{ steps.release.outputs.artifacts }}
+      clean_semver: ${{ steps.setup.outputs.clean_semver }}
+      metadata: ${{ steps.release.outputs.metadata }}
+      release-tag: ${{ steps.setup.outputs.release-tag }}
+      release-id: ${{ steps.release_id.outputs.release-id }}
+      
     permissions:
 
       attestations: write
@@ -85,6 +83,16 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    # Upload all built artifacts for attestation
+    - name: Upload build artifacts for attestation
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-artifacts
+        path: |
+          dist/*wtutf*tar.gz
+          dist/*wtutf*zip
+          dist/checksums.txt
+
     - name: Get Release ID
       id: release_id
       env:
@@ -97,21 +105,34 @@ jobs:
           /repos/${{ github.repository }}/releases | jq ".[] | select(.tag_name == \"$RELEASE_TAG\").id")
         echo "release-id=$release_id" | tee -a "$GITHUB_OUTPUT"
     
-    - name: Generate Attestation
-      id: attest
-      if: steps.setup.outputs.clean_semver == 'true'
-      uses: actions/attest-build-provenance@v2
-      with:
-        subject-path: |
-          dist/**/*wtutf*tar.gz
-          dist/**/*wtutf*zip
-          dist/checksums.txt
+  attest:
+    name: Generate Attestation
+    needs: [draft_release]
+    permissions:
+      attestations: write
+      id-token: write
+      contents: read
+    if: needs.draft_release.outputs.clean_semver == 'true'
+    uses: eliheady/wtutf/.github/workflows/attest.yml@c13c6fd98429f6761e11b919403ae787e3e87d8d
+    secrets: inherit
+    with:
+        subject-path: 'release/*'
 
+  notes:
+    runs-on: ubuntu-latest
+    needs: [draft_release, attest]
+    name: Add Release Notes
+    outputs:
+      image-digest: ${{ steps.metadata.outputs.image-digest }}
+      image-name: ${{ steps.metadata.outputs.image-name }}
+      release-id: ${{ steps.metadata.outputs.release-id }}
+
+    steps:
     - name: Collect Metadata
       id: metadata
       env:
-        ARTIFACTS: ${{ steps.release.outputs.artifacts }}
-        METADATA:  ${{ steps.release.outputs.metadata }}
+        ARTIFACTS: ${{ needs.draft_release.outputs.artifacts }}
+        METADATA:  ${{ needs.draft_release.outputs.metadata }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         echo "artifacts=$(echo "$ARTIFACTS" )" >> "$GITHUB_OUTPUT"
@@ -128,12 +149,12 @@ jobs:
     #    push-to-registry: true
 
     - name: Attestation Notes
-      if: steps.setup.outputs.clean_semver == 'true'
+      if: needs.draft_release.outputs.clean_semver == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_TAG: ${{ steps.setup.outputs.release-tag }}
-        RELEASE_ID: ${{ steps.release_id.outputs.release-id }}
-        ATTESTATION_URL: ${{ steps.attest.outputs.attestation-url }}
+        RELEASE_TAG: ${{ needs.draft_release.outputs.release-tag }}
+        RELEASE_ID: ${{ needs.draft_release.outputs.release-id }}
+        ATTESTATION_URL: ${{ needs.attest.outputs.attestation-url }}
       run: |-
         tmpfile=$(mktemp)
         RELEASE_NOTES_FILE=$tmpfile-notes.md

--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -113,7 +113,7 @@ jobs:
       id-token: write
       contents: read
     if: needs.draft_release.outputs.clean_semver == 'true'
-    uses: eliheady/wtutf/.github/workflows/attest.yml@c13c6fd98429f6761e11b919403ae787e3e87d8d
+    uses: eliheady/wtutf/.github/workflows/attest.yml@3550b0891a0a53bd2415c585357b3226009dc6d1
     secrets: inherit
     with:
         subject-path: 'release/*'

--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -113,10 +113,8 @@ jobs:
       id-token: write
       contents: read
     if: needs.draft_release.outputs.clean_semver == 'true'
-    uses: eliheady/wtutf/.github/workflows/attest.yml@7e50f5f9eae87d67038d21816f915f26bebe3d65
+    uses: eliheady/wtutf/.github/workflows/attest.yml@bdced0447dc7bf0808b1e13baceab95fdd64bd12
     secrets: inherit
-    with:
-      subject-path: 'release/*'
 
   notes:
     runs-on: ubuntu-latest
@@ -159,7 +157,7 @@ jobs:
         command (all artifacts are signed, change \`checksums.txt\` as needed for your use-case):
 
         \`\`\`shell
-        gh attestation verify checksums.txt -R ${{ github.repository }} -t $RELEASE_TAG
+        gh attestation verify checksums.txt -R ${{ github.repository }}
         \`\`\`
         EOF
         # "gh release edit" can sometimes create new releases, which is not what we want here.

--- a/Readme.md
+++ b/Readme.md
@@ -161,10 +161,10 @@ Releases include a build provenance attestation step that uses the [attest-build
 
 Download a build from the Releases section at right or [here](https://github.com/eliheady/wtutf/releases).
 
-The attestation results for past releases are at [https://github.com/eliheady/wtutf/attestations](https://github.com/eliheady/wtutf/attestations). To verify this release, install `gh` and run this command (change the artifact as needed for your use-case):
+The attestation results for past releases are at [https://github.com/eliheady/wtutf/attestations](https://github.com/eliheady/wtutf/attestations). To verify a build artifact, install `gh` and run this command (change the artifact as needed for your use-case):
 
 ```shell
-gh attestation verify wtutf_v0.0.4_darwin_arm64.tar.gz -R eliheady/wtutf
+gh attestation verify wtutf_v0.0.5_darwin_arm64.tar.gz -R eliheady/wtutf
 ```
 
 See the GitHub [documentation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli) for alternative verification steps.


### PR DESCRIPTION
This changes the build provenance attestation in the release candidate workflow to sign the artifacts in a reusable workflow, which is a requirement for SLSA level 3 attestation.