### PR TITLE
Docker image build provenance attestation

### DIFF
--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -80,7 +80,7 @@ jobs:
             echo "Error: If subject-checksums is provided, artifact-restore-path and artifact-upload-name must be provided."
             exit 1
           fi
-          restore-artifacts=true
+          restore_artifacts=true
           satisfied_args=true
         fi
 
@@ -93,7 +93,7 @@ jobs:
             echo "Error: If subject-checksums is provided, artifact-restore-path and artifact-upload-name must be provided."
             exit 1
           fi
-          restore-artifacts=true
+          restore_artifacts=true
           satisfied_args=true
         fi
 

--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -69,14 +69,8 @@ jobs:
     - name: Validate inputs
       id: validate-inputs
       run: |
-        echo "subject-path='${{ inputs.subject-path }}'"
-        echo "subject-digest='${{ inputs.subject-digest }}'"
-        echo "subject-name='${{ inputs.subject-name }}'"
-        echo "subject-checksums='${{ inputs.subject-checksums }}'"
-        echo "push-to-registry='${{ inputs.push-to-registry }}'"
-        echo "show-summary='${{ inputs.show-summary }}'"
-
         satisfied_args=false
+        restore_artifacts=false
         if [ -n "${{ inputs.subject-checksums }}" ]; then
           if [ -n "${{ inputs.subject-name }}" -o -n "${{ inputs.subject-path }}" ]; then
             echo "Error: If subject-checksums is provided, subject-name and subject-path must not be provided."
@@ -86,7 +80,7 @@ jobs:
             echo "Error: If subject-checksums is provided, artifact-restore-path and artifact-upload-name must be provided."
             exit 1
           fi
-          echo "restore-artifacts='true'" >> "$GITHUB_OUTPUT"
+          restore-artifacts=true
           satisfied_args=true
         fi
 
@@ -99,7 +93,7 @@ jobs:
             echo "Error: If subject-checksums is provided, artifact-restore-path and artifact-upload-name must be provided."
             exit 1
           fi
-          echo "restore-artifacts='true'" >> "$GITHUB_OUTPUT"
+          restore-artifacts=true
           satisfied_args=true
         fi
 
@@ -120,10 +114,22 @@ jobs:
           exit 1
         fi
 
+        echo "restore-artifacts=$restore_artifacts" >> "$GITHUB_OUTPUT"
+
+        echo "restore-artifacts=$restore_artifacts"
+        echo "artifact-upload-name='${{ inputs.artifact-upload-name }}'"
+        echo "artifact-restore-path='${{ inputs.artifact-restore-path }}'"
+        echo "subject-path='${{ inputs.subject-path }}'"
+        echo "subject-digest='${{ inputs.subject-digest }}'"
+        echo "subject-name='${{ inputs.subject-name }}'"
+        echo "subject-checksums='${{ inputs.subject-checksums }}'"
+        echo "push-to-registry='${{ inputs.push-to-registry }}'"
+        echo "show-summary='${{ inputs.show-summary }}'"
+
     # Download the artifacts uploaded by the build job
     - name: Download build artifacts
       id: download-artifacts
-      if: ${{ steps.validate-inputs.outputs.restore-artifacts == 'true' }}
+      if: steps.validate-inputs.outputs.restore-artifacts == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -5,11 +5,30 @@ name: "CALL: Sign Artifact"
 on:
   workflow_call:
     inputs:
+
+      artifact-upload-name:
+        description: The name of the uploaded artifact bundle. Required if subject-checksums or subject-path is provided.
+        type: string
     
+      artifact-restore-path:
+        description: The local path to restore the artifact bundle. Required if subject-checksums or subject-path is provided.
+        type: string
+
       subject-path:
         required: false
         type: string
-        default: 'release'
+
+      subject-name:
+        required: false
+        type: string
+
+      subject-digest:
+        required: false
+        type: string
+
+      subject-checksums:
+        required: false
+        type: string
 
       push-to-registry:
         required: false
@@ -18,6 +37,7 @@ on:
       show-summary:
         required: false
         type: boolean
+
     outputs:
       attestation-url:
         value: ${{ jobs.sign-artifact.outputs.attestation-url }}
@@ -45,22 +65,84 @@ jobs:
       contents: read
 
     steps:
+
+    - name: Validate inputs
+      id: validate-inputs
+      run: |
+        echo "subject-path='${{ inputs.subject-path }}'"
+        echo "subject-digest='${{ inputs.subject-digest }}'"
+        echo "subject-name='${{ inputs.subject-name }}'"
+        echo "subject-checksums='${{ inputs.subject-checksums }}'"
+        echo "push-to-registry='${{ inputs.push-to-registry }}'"
+        echo "show-summary='${{ inputs.show-summary }}'"
+
+        satisfied_args=false
+        if [ -n "${{ inputs.subject-checksums }}" ]; then
+          if [ -n "${{ inputs.subject-name }}" -o -n "${{ inputs.subject-path }}" ]; then
+            echo "Error: If subject-checksums is provided, subject-name and subject-path must not be provided."
+            exit 1
+          fi
+          if [ -z "${{ inputs.artifact-restore-path }}" -o -z "${{ inputs.artifact-upload-name }}" ]; then
+            echo "Error: If subject-checksums is provided, artifact-restore-path and artifact-upload-name must be provided."
+            exit 1
+          fi
+          echo "restore-artifacts='true'" >> "$GITHUB_OUTPUT"
+          satisfied_args=true
+        fi
+
+        if [ -n "${{ inputs.subject-path }}" ]; then
+          if [ -n "${{ inputs.subject-name }}" -o -n "${{ inputs.subject-checksums }}" ]; then
+            echo "Error: If subject-path is provided, subject-name and subject-checksums must not be provided."
+            exit 1
+          fi
+          if [ -z "${{ inputs.artifact-restore-path }}" -o -z "${{ inputs.artifact-upload-name }}" ]; then
+            echo "Error: If subject-checksums is provided, artifact-restore-path and artifact-upload-name must be provided."
+            exit 1
+          fi
+          echo "restore-artifacts='true'" >> "$GITHUB_OUTPUT"
+          satisfied_args=true
+        fi
+
+        if [ -n "${{ inputs.subject-digest }}" ]; then
+          if [ -z "${{ inputs.subject-name }}" ]; then
+            echo "Error: If subject-digest is provided, subject-name must be provided."
+            exit 1
+          fi
+          if [ -n "${{ inputs.subject-path }}" -o -n "${{ inputs.subject-checksums }}" ]; then
+            echo "Error: If subject-digest is provided, subject-path and subject-checksums must not be provided."
+            exit 1
+          fi
+          satisfied_args=true
+        fi
+
+        if [ "$satisfied_args" == "false" ]; then
+          echo "Error: At least one of subject-path, subject-name, or subject-checksums must be provided."
+          exit 1
+        fi
+
     # Download the artifacts uploaded by the build job
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      id: download-artifacts
+      if: ${{ steps.validate-inputs.outputs.restore-artifacts == 'true' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
-        name: build-artifacts
-        path: ${{ inputs.subject-path }}
+        name: ${{ inputs.artifact-upload-name }}
+        path: ${{ inputs.artifact-restore-path }}
 
     - name: Attest Build Provenance
       id: attest
-      uses: actions/attest-build-provenance@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
       with:
-        subject-path: ${{ inputs.subject-path }}/*
+        subject-path: ${{ inputs.subject-path }}
+        subject-checksums: ${{ inputs.subject-checksums }}
         push-to-registry: ${{ inputs.push-to-registry }}
         show-summary: ${{ inputs.show-summary }}
+        subject-name: ${{ inputs.subject-name }}
+        subject-digest: ${{ inputs.subject-digest }}
 
     - name: Set outputs
       id: collect

--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -96,9 +96,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        #echo "release-assets=$(gh release view ${{ steps.setup.outputs.release-tag }} --json assets -q '.assets[].name' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
-        echo "image-digest=$(echo "${{ steps.release.outputs.artifacts}}" | jq -r '.[]|select(.type=="Docker Manifest")|select(.name|test(":v"))|.extra.Digest')" >> "$GITHUB_OUTPUT"
-        echo "image-name=$(echo "${{ steps.release.outputs.artifacts}}" | jq -r '.[]|select(.type=="Docker Manifest")|select(.name|test(":v"))|.name|split(":")[0]')" >> "$GITHUB_OUTPUT"
+        echo "image-digest=$(echo '${{ steps.release.outputs.artifacts}}' | jq -r '.[]|select(.type=="Docker Manifest")|select(.name|test(":v"))|.extra.Digest')" >> "$GITHUB_OUTPUT"
+        echo "image-name=$(echo '${{ steps.release.outputs.artifacts}}' | jq -r '.[]|select(.type=="Docker Manifest")|select(.name|test(":v"))|.name|split(":")[0]')" >> "$GITHUB_OUTPUT"
 
     # Upload all built artifacts for attestation
     - name: Upload build artifacts for attestation
@@ -156,7 +155,10 @@ jobs:
 
   notes:
     runs-on: ubuntu-latest
-    needs: [release, attest-packages, attest-images]
+    needs:
+      - release
+      - attest-packages
+      - attest-images
     name: Add Release Notes
 
     steps:

--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -129,7 +129,7 @@ jobs:
       id-token: write
       contents: read
     if: needs.release.outputs.clean_semver == 'true'
-    uses: eliheady/wtutf/.github/workflows/attest.yml@8f064c07c84989ab32195a225441b2dde103088d
+    uses: eliheady/wtutf/.github/workflows/attest.yml@0edc67d4f0b1dd68f8f0d93477cb1cb255c68a88
     secrets: inherit
     with:
       artifact-upload-name: build-artifacts
@@ -148,7 +148,7 @@ jobs:
       #packages: write # push attestation to the registry
     if: needs.release.outputs.image-name != '' && needs.release.outputs.image-digest != ''
     #if: needs.release.outputs.clean_semver == 'true' && needs.release.outputs.image-name != '' && needs.release.outputs.image-digest != ''
-    uses: eliheady/wtutf/.github/workflows/attest.yml@8f064c07c84989ab32195a225441b2dde103088d
+    uses: eliheady/wtutf/.github/workflows/attest.yml@0edc67d4f0b1dd68f8f0d93477cb1cb255c68a88
     secrets: inherit
     with:
       subject-name: ${{ needs.release.outputs.image-name }}

--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -96,7 +96,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "release-assets=$(gh release view ${{ steps.setup.outputs.release-tag }} --json assets -q '.assets[].name' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+        #echo "release-assets=$(gh release view ${{ steps.setup.outputs.release-tag }} --json assets -q '.assets[].name' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
         echo "image-digest=$(echo "${{ steps.release.outputs.artifacts}}" | jq -r '.[]|select(.type=="Docker Manifest")|select(.name|test(":v"))|.extra.Digest')" >> "$GITHUB_OUTPUT"
         echo "image-name=$(echo "${{ steps.release.outputs.artifacts}}" | jq -r '.[]|select(.type=="Docker Manifest")|select(.name|test(":v"))|.name|split(":")[0]')" >> "$GITHUB_OUTPUT"
 
@@ -122,14 +122,14 @@ jobs:
         echo "release-id=$release_id" | tee -a "$GITHUB_OUTPUT"
 
   attest-packages:
-    name: Generate Package Attestation
+    name: Package Provenance Attestation
     needs: [release]
     permissions:
       attestations: write
       id-token: write
       contents: read
     if: needs.release.outputs.clean_semver == 'true'
-    uses: eliheady/wtutf/.github/workflows/attest.yml@779bdf87e8be92ce68ed73f3c25da0fe24e54b3c
+    uses: eliheady/wtutf/.github/workflows/attest.yml@8f064c07c84989ab32195a225441b2dde103088d
     secrets: inherit
     with:
       artifact-upload-name: build-artifacts
@@ -139,7 +139,7 @@ jobs:
         dist/checksums*
     
   attest-images:
-    name: Generate Image Attestation
+    name: Image Provenance Attestation
     needs: [release]
     permissions:
       attestations: write
@@ -148,7 +148,7 @@ jobs:
       #packages: write # push attestation to the registry
     if: needs.release.outputs.image-name != '' && needs.release.outputs.image-digest != ''
     #if: needs.release.outputs.clean_semver == 'true' && needs.release.outputs.image-name != '' && needs.release.outputs.image-digest != ''
-    uses: eliheady/wtutf/.github/workflows/attest.yml@779bdf87e8be92ce68ed73f3c25da0fe24e54b3c
+    uses: eliheady/wtutf/.github/workflows/attest.yml@8f064c07c84989ab32195a225441b2dde103088d
     secrets: inherit
     with:
       subject-name: ${{ needs.release.outputs.image-name }}

--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -11,7 +11,7 @@ on:
 permissions: read-all
 
 jobs:
-  draft_release:
+  release:
 
     name: Draft Release
     runs-on: ubuntu-latest
@@ -23,6 +23,9 @@ jobs:
       metadata: ${{ steps.release.outputs.metadata }}
       release-tag: ${{ steps.setup.outputs.release-tag }}
       release-id: ${{ steps.release_id.outputs.release-id }}
+      release-assets: ${{ steps.artifacts.outputs.release-assets }}
+      image-name: ${{ steps.artifacts.outputs.image-name }}
+      image-digest: ${{ steps.artifacts.outputs.image-digest }}
       
     permissions:
 
@@ -88,6 +91,15 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Get Release Artifacts
+      id: artifacts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "release-assets=$(gh release view ${{ steps.setup.outputs.release-tag }} --json assets -q '.assets[].name' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+        echo "image-digest=$(echo "${{ steps.release.outputs.artifacts}}" | jq -r '.[]|select(.type=="Docker Manifest")|select(.name|test(":v"))|.extra.Digest')" >> "$GITHUB_OUTPUT"
+        echo "image-name=$(echo "${{ steps.release.outputs.artifacts}}" | jq -r '.[]|select(.type=="Docker Manifest")|select(.name|test(":v"))|.name|split(":")[0]')" >> "$GITHUB_OUTPUT"
+
     # Upload all built artifacts for attestation
     - name: Upload build artifacts for attestation
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -108,62 +120,85 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           /repos/${{ github.repository }}/releases | jq ".[] | select(.tag_name == \"$RELEASE_TAG\").id")
         echo "release-id=$release_id" | tee -a "$GITHUB_OUTPUT"
-    
-  attest:
-    name: Generate Attestation
-    needs: [draft_release]
+
+  attest-packages:
+    name: Generate Package Attestation
+    needs: [release]
     permissions:
       attestations: write
       id-token: write
       contents: read
-    if: needs.draft_release.outputs.clean_semver == 'true'
-    uses: eliheady/wtutf/.github/workflows/attest.yml@b2b9b334200a97ff22f53ba64295f7a86e45c4e5
+    if: needs.release.outputs.clean_semver == 'true'
+    uses: eliheady/wtutf/.github/workflows/attest.yml@779bdf87e8be92ce68ed73f3c25da0fe24e54b3c
     secrets: inherit
+    with:
+      artifact-upload-name: build-artifacts
+      artifact-restore-path: dist
+      subject-path: |
+        dist/*wtutf*
+        dist/checksums*
+    
+  attest-images:
+    name: Generate Image Attestation
+    needs: [release]
+    permissions:
+      attestations: write
+      id-token: write
+      contents: read
+      #packages: write # push attestation to the registry
+    if: needs.release.outputs.image-name != '' && needs.release.outputs.image-digest != ''
+    #if: needs.release.outputs.clean_semver == 'true' && needs.release.outputs.image-name != '' && needs.release.outputs.image-digest != ''
+    uses: eliheady/wtutf/.github/workflows/attest.yml@779bdf87e8be92ce68ed73f3c25da0fe24e54b3c
+    secrets: inherit
+    with:
+      subject-name: ${{ needs.release.outputs.image-name }}
+      subject-digest: ${{ needs.release.outputs.image-digest }}
 
   notes:
     runs-on: ubuntu-latest
-    needs: [draft_release, attest]
+    needs: [release, attest-packages, attest-images]
     name: Add Release Notes
 
     steps:
     - name: Debug Attest Outputs
       run: |
-        echo "Attest outputs: ${{ toJson(needs.attest.outputs) }}"
-
-    #- name: Generate container attestation
-    #  uses: actions/attest-build-provenance@v2
-    #  with:
-    #    subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-    #    # todo: figure out docker manifest goreleaser issue, then set these in the metadata step
-    #    #echo "image-digest=$(echo "$ARTIFACTS" | jq -r '.[]|select(.type=="Docker Manifest")|select(.name|test(":v"))|.extra.Digest')" >> "$GITHUB_OUTPUT"
-    #    #echo "image-name=$(echo "$ARTIFACTS" | jq -r '.[]|select(.type=="Docker Manifest")|select(.name|test(":v"))|.name|split(":")[0]')" >> "$GITHUB_OUTPUT"
-    #    subject-digest: ${{ steps.metadata.outputs.image-digest }}
-    #    push-to-registry: true
+        echo "Attest packages outputs: ${{ toJson(needs.attest-packages.outputs) }}"
+        echo "Attest images outputs: ${{ toJson(needs.attest-images.outputs) }}"
 
     - name: Attestation Notes
-      if: needs.draft_release.outputs.clean_semver == 'true'
+      if: needs.release.outputs.clean_semver == 'true'
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        RELEASE_TAG: ${{ needs.draft_release.outputs.release-tag }}
-        RELEASE_ID: ${{ needs.draft_release.outputs.release-id }}
-        ATTESTATION_URL: ${{ needs.attest.outputs.attestation-url }}
+        RELEASE_TAG: ${{ needs.release.outputs.release-tag }}
+        RELEASE_ID: ${{ needs.release.outputs.release-id }}
+        ATTESTATION_URL_PACKAGES: ${{ needs.attest-packages.outputs.attestation-url }}
+        ATTESTATION_URL_IMAGES: ${{ needs.attest-images.outputs.attestation-url }}
       run: |-
+        if [ -n "$ATTESTATION_URL_PACKAGES" ]; then
+          PKG_ATTEST="  - [$ATTESTATION_URL_PACKAGES]($ATTESTATION_URL_PACKAGES)"
+        fi
+        if [ -n "$ATTESTATION_URL_IMAGES" ]; then
+          IMG_ATTEST="  - [$ATTESTATION_URL_IMAGES]($ATTESTATION_URL_IMAGES)"
+        fi
         tmpfile=$(mktemp)
         RELEASE_NOTES_FILE=$tmpfile-notes.md
         echo $RELEASE_NOTES_FILE
         gh release view $RELEASE_TAG --json body -R ${{ github.repository }} | jq -r '.body' > $RELEASE_NOTES_FILE
+
         cat >> $RELEASE_NOTES_FILE <<EOF
         ## Verify Release Artifacts
 
-        The attestation results for this release are at [$ATTESTATION_URL]($ATTESTATION_URL).
+        Attestation(s) for this release:
+        $PKG_ATTEST
+        $IMG_ATTEST
 
-        To verify this release: download a release artifact, install \`gh\` and run this
-        command (all artifacts are signed, change \`checksums.txt\` as needed for your use-case):
+        To verify packages in this release: download a release artifact, install \`gh\` and run this command (all artifacts are signed, change \`checksums.txt\` as needed for your use-case):
 
         \`\`\`shell
         gh attestation verify checksums.txt -R ${{ github.repository }}
         \`\`\`
         EOF
+
         # "gh release edit" can sometimes create new releases, which is not what we want here.
         #gh release edit ${RELEASE_TAG} --notes-file $RELEASE_NOTES_FILE
         gh api --method PATCH \

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
         goarch: "386"
       - goos: linux
         goarch: "386"
-    binary: wtutf-{{ .Os }}-{{ .Arch }}
+    binary: wtutf
     mod_timestamp: "{{ .CommitTimestamp }}"
     # fixme: failed to add: 'dist/go_darwin_arm64_v8.0/wtutf-darwin-arm64.h' -> 'wtutf-darwin-arm64.h': dist/go_darwin_arm64_v8.0/wtutf-darwin-arm64.h: lstat dist/go_darwin_arm64_v8.0/wtutf-darwin-arm64.h: no such file or directory
     #buildmode: "c-archive"
@@ -33,6 +33,7 @@ builds:
       - "-X main.Version={{ .Version }}"
       - "-X main.Commit={{ .FullCommit }}"
       - "-X main.CommitDate={{ .CommitDate }}"
+
 before:
   hooks:
     - go fmt ./...
@@ -59,29 +60,15 @@ sboms:
   - id: source
     artifacts: source
 
-signs:
-  - cmd: cosign
-    artifacts: checksum
-    certificate: "${artifact}.pem"
-    output: true
-    args:
-      - "sign-blob"
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
-      - "${artifact}"
-      - "--yes" # needed on cosign 2.0.0+
-
 dockers:
   - image_templates:
       - &amd_image "ghcr.io/eliheady/{{ .ProjectName }}:{{ .Tag }}-amd64"
     goos: linux
     goarch: amd64
     use: buildx
-    ids:
-      - build
     dockerfile: Containerfile
     build_flag_templates:
-      - --platform {{ .Os }}/amd64
+      - --platform=linux/amd64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.url={{ .GitURL }}
@@ -96,11 +83,9 @@ dockers:
     goos: linux
     goarch: arm64
     use: buildx
-    ids:
-      - build
     dockerfile: Containerfile
     build_flag_templates:
-      - --platform {{ .Os }}/arm64
+      - --platform=linux/arm64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.url={{ .GitURL }}
@@ -110,17 +95,18 @@ dockers:
       - --label=org.opencontainers.image.version={{ .Version }}
       - --label=org.opencontainers.image.source={{ .GitURL }}
       - --label=org.opencontainers.image.licenses=MIT
-# docker_manifests:
-#   - name_template: ghcr.io/eliheady/{{ .ProjectName }}:{{ .Tag }}
-#     image_templates:
-#       - *amd_image
-#       - *arm_image
 
-docker_signs:
-  - cmd: cosign
-    artifacts: images
-    output: true
-    args:
-      - "sign"
-      - "${artifact}"
-      - "--yes" # needed on cosign 2.0.0+
+docker_manifests:
+  - name_template: ghcr.io/eliheady/{{ .ProjectName }}:{{ .Tag }}
+    image_templates:
+      - *amd_image
+      - *arm_image
+
+#docker_signs:
+#  - cmd: cosign
+#    artifacts: images
+#    output: true
+#    args:
+#      - "sign"
+#      - "${artifact}"
+#      - "--yes" # needed on cosign 2.0.0+

--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,4 @@ FROM scratch
 
 COPY wtutf /usr/local/bin/
 
-WORKDIR /tmp
-
 ENTRYPOINT ["/usr/local/bin/wtutf"]


### PR DESCRIPTION
This improves the RC build job to support image provenance attestation using GitHub attest-build-provenance action.

The reusable workflow `attest.yml` is improved to support parameterized and conditional artifact downloads, and input validation.

Goreleaser `docker_signs` is commented and retained for now for testing of the alternative GitHub action attestation method.