### PR TITLE
reproducible binaries work

### DIFF
--- a/.github/workflows/make-rc.yml
+++ b/.github/workflows/make-rc.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: ^1.23
+        go-version-file: 'go.mod'
 
     - name: Install cosign
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
     # fixme: failed to add: 'dist/go_darwin_arm64_v8.0/wtutf-darwin-arm64.h' -> 'wtutf-darwin-arm64.h': dist/go_darwin_arm64_v8.0/wtutf-darwin-arm64.h: lstat dist/go_darwin_arm64_v8.0/wtutf-darwin-arm64.h: no such file or directory
     #buildmode: "c-archive"
     ldflags:
-      - "-s -w"
+      - "-s -w -buildid="
       - "-X main.date={{ .CommitDate }}"
       - "-X main.Version={{ .Version }}"
       - "-X main.Commit={{ .FullCommit }}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eliheady/wtutf
 
-go 1.26.0
+go 1.26.5
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
- changes the setup-go action to install the version in go.mod
- adds '-buildid=' to ldflags
- bumps go.mod go version to 1.26.5